### PR TITLE
fix: prevent NPE when findFirst() returns empty result

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -194,6 +194,9 @@ export class CRSQLitePreparedQuery<
 		if (this.oneTime) {
 			void stmt.finalize(this.tx)
 		}
+		if (!row) {
+			return undefined;
+		}
 		return this.customResultMapper ? this.customResultMapper([row]) : row
 	}
 


### PR DESCRIPTION
I founded an issue where calling the `findFirst()` method would cause a NPE when the query result is empty. The problem occurs because the code doesn't directly return undefined when no results, leading to subsequent operations on a null/undefined value.

This PR adds a proper null check to return undefined immediately when no row is found.